### PR TITLE
Update repository name from ethtokyo2025-sandbox to vsr

### DIFF
--- a/README.md
+++ b/README.md
@@ -13,8 +13,8 @@ VSR is a verifiable social recommendation system using zero-knowledge proofs wit
 
 1. **Clone the repository**
    ```bash
-   git clone https://github.com/TideQuest/ethtokyo2025-sandbox.git
-   cd ethtokyo2025-sandbox
+   git clone https://github.com/TideQuest/vsr.git
+   cd vsr
    ```
 
 2. **Configure environment variables**

--- a/docs/openapi.yaml
+++ b/docs/openapi.yaml
@@ -5,7 +5,7 @@ info:
   version: 1.0.0
   contact:
     name: TideQuest Team
-    url: https://github.com/TideQuest/ethtokyo2025-sandbox
+    url: https://github.com/TideQuest/vsr
 servers:
   - url: http://localhost:3000
     description: Development server


### PR DESCRIPTION
## Summary
- Updated repository name references from `ethtokyo2025-sandbox` to `vsr` in documentation and configuration files
- Modified `docs/openapi.yaml` contact URL 
- Updated `README.md` git clone command and directory references
